### PR TITLE
Add resume download link to experience page and navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,11 @@ brand:
   product-name: "HireDoc"
   product-url: "https://hiredoc.co"
   quiz-url: "https://mohammad-danish-npboaynr.scoreapp.com"
+  # Public resume, hosted on Google Drive so it can be swapped without a site
+  # rebuild — replace the file in Drive and every link here stays correct.
+  # This is the direct-download form of the URL; the /file/d/<id>/view form
+  # opens the Drive preview instead if you'd rather people read it in place.
+  resume-url: "https://drive.google.com/uc?export=download&id=1oqCVYgLdbU-Um2__LEIP-9QL-IuoYKxf"
 
 # ---------------------------------------------------------------------------
 # Navigation

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,6 +20,22 @@
         <a href="{{ link[1] | relative_url }}"{% if page.url contains target %} aria-current="page"{% endif %}>{{ link[0] }}</a>
         {%- endif %}
       {%- endfor %}
+      {%- if site.brand.resume-url %}
+        {%- comment -%}
+          Kept out of navbar-links so it can carry the download affordance and
+          its own screen-reader text, rather than the generic external-link
+          treatment above.
+        {%- endcomment -%}
+        <a class="nav-resume" href="{{ site.brand.resume-url | escape }}" target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"
+               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M8 1.75v8.25"/>
+            <path d="M4.6 6.9 8 10.3l3.4-3.4"/>
+            <path d="M2.25 11.9v1.35c0 .55.45 1 1 1h9.5c.55 0 1-.45 1-1V11.9"/>
+          </svg>
+          Resume<span class="sr-only"> (PDF, opens in a new tab)</span>
+        </a>
+      {%- endif %}
       {%- if site.navbar-cta %}
         <a class="btn btn-sm" href="{{ site.navbar-cta.url | default: site.brand.quiz-url }}">{{ site.navbar-cta.label }}</a>
       {%- endif %}

--- a/css/brand.css
+++ b/css/brand.css
@@ -295,6 +295,19 @@ main {
   text-underline-offset: 5px;
 }
 
+/* Resume download. Reads as a nav link, but carries a download glyph so it's
+   distinguishable from the pages either side of it. */
+.nav-resume {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.nav-resume svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
+
 .nav-toggle {
   display: none;
   background: none;

--- a/experience.html
+++ b/experience.html
@@ -18,11 +18,10 @@ description: "12+ years of software engineering: AI-driven onboarding contributi
     {%- if site.brand.resume-url %}
     <div class="btn-row">
       <a class="btn" href="{{ site.brand.resume-url | escape }}" target="_blank" rel="noopener">
-        Download my resume<span class="sr-only"> (opens in a new tab)</span>
+        Download my resume<span class="sr-only"> (PDF, opens in a new tab)</span>
       </a>
       <a class="btn btn-ghost" href="mailto:{{ site.author.email }}">Email me</a>
     </div>
-    <p class="btn-note">PDF &middot; no signup &middot; the same document I send recruiters</p>
     {%- endif %}
   </div>
 

--- a/experience.html
+++ b/experience.html
@@ -15,6 +15,15 @@ description: "12+ years of software engineering: AI-driven onboarding contributi
       Frontend-heavy full-stack work across fintech, travel, property
       management, banking, and games &mdash; plus the product I run now.
     </p>
+    {%- if site.brand.resume-url %}
+    <div class="btn-row">
+      <a class="btn" href="{{ site.brand.resume-url | escape }}" target="_blank" rel="noopener">
+        Download my resume<span class="sr-only"> (opens in a new tab)</span>
+      </a>
+      <a class="btn btn-ghost" href="mailto:{{ site.author.email }}">Email me</a>
+    </div>
+    <p class="btn-note">PDF &middot; no signup &middot; the same document I send recruiters</p>
+    {%- endif %}
   </div>
 
   <div class="answer">
@@ -101,8 +110,15 @@ description: "12+ years of software engineering: AI-driven onboarding contributi
       senior engineering resume should actually say.
     </p>
     <div class="btn-row">
+      {%- if site.brand.resume-url %}
+      <a class="btn" href="{{ site.brand.resume-url | escape }}" target="_blank" rel="noopener">
+        Download my resume<span class="sr-only"> (PDF, opens in a new tab)</span>
+      </a>
+      <a class="btn btn-ghost" href="mailto:{{ site.author.email }}">Email me</a>
+      {%- else %}
       <a class="btn" href="mailto:{{ site.author.email }}">Email me</a>
-      <a class="btn btn-ghost" href="https://www.linkedin.com/in/mdanishs">Connect on LinkedIn</a>
+      {%- endif %}
+      <a class="btn btn-ghost" href="{{ site.social-network-links.LinkedIn }}" rel="noopener">Connect on LinkedIn</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
Added a downloadable resume feature to the site, making it easily accessible from both the experience page and main navigation. The resume is hosted on Google Drive to allow updates without requiring a site rebuild.

## Key Changes
- **Experience page**: Added resume download button and email CTA in two locations (intro section and hiring section) with conditional rendering based on `site.brand.resume-url` config
- **Navigation**: Added a dedicated resume link in the navbar with a download icon SVG to distinguish it from regular page links
- **Styling**: Added `.nav-resume` CSS class to style the navigation resume link with flexbox layout and proper icon sizing
- **Configuration**: Added `resume-url` to `_config.yml` pointing to a Google Drive direct-download link, with documentation explaining the approach

## Implementation Details
- Resume links open in a new tab with `target="_blank"` and `rel="noopener"` for security
- Includes screen reader text to clarify that links open in new tabs and are PDFs
- Conditional rendering (`{%- if site.brand.resume-url %}`) allows the feature to be toggled off by removing the config value
- Google Drive URL uses the direct-download form (`/uc?export=download`) rather than the preview form, allowing file updates without changing links
- LinkedIn link refactored to use `site.social-network-links.LinkedIn` config for consistency
- Download icon is decorative (`aria-hidden="true"`) to avoid redundant screen reader announcements

https://claude.ai/code/session_0175NALFBVFBpDW71i2tXCHp