### PR TITLE
Enhance Product schema markup and fix resume-help URL consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 _site
 .sass-cache
 .vagrant
+# Left untracked on purpose: the Gemfile is unpinned so `bundle install`
+# tracks whatever GitHub Pages is running. Committing a lockfile would pin
+# local builds to one resolution and defeat that.
+Gemfile.lock
 
 # general
 .DS_Store

--- a/404.html
+++ b/404.html
@@ -15,7 +15,7 @@ sitemap: false
       everything lives now.
     </p>
     <ul>
-      <li><a href="{{ '/resume-help' | relative_url }}">Resume help</a> &mdash; who I help and how</li>
+      <li><a href="{{ '/resume-help/' | relative_url }}">Resume help</a> &mdash; who I help and how</li>
       <li><a href="{{ '/experience' | relative_url }}">Experience</a> &mdash; roles, impact, and credentials</li>
       <li><a href="{{ '/projects' | relative_url }}">Projects</a> &mdash; selected work</li>
       <li><a href="{{ '/about' | relative_url }}">About</a> &mdash; the longer story</li>

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,18 @@ brand:
   linkedin-followers: "6,400+"
   product-name: "HireDoc"
   product-url: "https://hiredoc.co"
+  # Product image for the HireDoc JSON-LD on /resume-help/. Google treats
+  # `image` as required on Product markup, so this must resolve to a crawlable
+  # file. Swap in a real HireDoc screenshot when there is one; a square or 4:3
+  # crop is what Google prefers.
+  product-image: "/img/og-card.png"
+  # Real, verifiable rating for HireDoc. Google lists aggregateRating as a
+  # non-critical missing field on the Product markup, but publishing a rating
+  # you cannot back up with real reviews breaks their structured data policy.
+  # Uncomment and fill in only once the numbers are genuine.
+  # product-rating:
+  #   value: "4.9"
+  #   count: "37"
   quiz-url: "https://mohammad-danish-npboaynr.scoreapp.com"
   # Public resume, hosted on Google Drive so it can be swapped without a site
   # rebuild — replace the file in Drive and every link here stays correct.
@@ -54,7 +66,7 @@ brand:
 # ---------------------------------------------------------------------------
 
 navbar-links:
-  Resume Help: "resume-help"
+  Resume Help: "resume-help/"
   Experience: "experience"
   Projects: "projects"
   About: "about"

--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -163,10 +163,33 @@
       "description": "An interview-based resume rewrite for software engineers who moved to Canada or the United States. Surfaces scale, ownership, and measurable impact that a standard rewrite would miss.",
       "brand": { "@id": "https://hiredoc.co/#organization" },
       "url": {{ site.brand.product-url | jsonify }},
+      {%- comment -%}
+        image is a required field for Google's Product markup — without it the
+        item is invalid and drops out of rich results entirely. Set
+        brand.product-image in _config.yml; falls back to the site OG card.
+      {%- endcomment -%}
+      "image": {{ site.brand.product-image | default: "/img/og-card.png" | absolute_url | jsonify }},
+      {%- comment -%}
+        aggregateRating and review are optional. Google flags them as
+        non-critical "missing field" suggestions, but inventing either one is a
+        policy violation, so they are only emitted once brand.product-rating
+        holds real numbers you can point at a public source for.
+      {%- endcomment -%}
+      {%- assign rating = site.brand.product-rating -%}
+      {%- if rating and rating.value and rating.count %}
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": {{ rating.value | jsonify }},
+        "reviewCount": {{ rating.count | jsonify }},
+        "bestRating": "5",
+        "worstRating": "1"
+      },
+      {%- endif %}
       "offers": [
         {
           "@type": "Offer",
           "name": "Self-serve",
+          "sku": "hiredoc-self-serve",
           "price": "49",
           "priceCurrency": "USD",
           "url": {{ site.brand.product-url | jsonify }},
@@ -175,6 +198,7 @@
         {
           "@type": "Offer",
           "name": "With analyst video review",
+          "sku": "hiredoc-analyst-review",
           "price": "70",
           "priceCurrency": "USD",
           "url": {{ site.brand.product-url | jsonify }},

--- a/about.html
+++ b/about.html
@@ -70,7 +70,7 @@ profile-page: true
     <p>
       It&rsquo;s the same problem as my day job, honestly. Good work is worthless if
       the person evaluating it can&rsquo;t see it.
-      <a href="{{ '/resume-help' | relative_url }}">More on how I help &rarr;</a>
+      <a href="{{ '/resume-help/' | relative_url }}">More on how I help &rarr;</a>
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ description: "Mohammad Danish Siddiqui is a senior frontend engineer with 12+ ye
         </p>
         <div class="btn-row">
           <a class="btn" href="{{ site.brand.quiz-url }}">Show me why I&rsquo;m not getting callbacks</a>
-          <a class="btn btn-ghost" href="{{ '/resume-help' | relative_url }}">See how I can help</a>
+          <a class="btn btn-ghost" href="{{ '/resume-help/' | relative_url }}">See how I can help</a>
         </div>
         <p class="btn-note">Free &middot; 3 minutes &middot; no signup &middot; instant score</p>
       </div>
@@ -135,7 +135,7 @@ description: "Mohammad Danish Siddiqui is a senior frontend engineer with 12+ ye
           interview &mdash; it asks about your work instead of paraphrasing the
           page, then rebuilds your experience around the impact you left out.
         </p>
-        <p><a href="{{ '/resume-help' | relative_url }}">See how it works &rarr;</a></p>
+        <p><a href="{{ '/resume-help/' | relative_url }}">See how it works &rarr;</a></p>
       </div>
       <div class="card">
         <p class="card-meta">Free</p>


### PR DESCRIPTION
## Summary
This PR improves the JSON-LD Product schema markup for Google rich results and standardizes internal URL formatting across the site.

## Key Changes

**Schema Markup Enhancements (_includes/schema.html)**
- Added required `image` field to Product markup with fallback to OG card image
- Implemented optional `aggregateRating` field that only renders when real rating data is configured
- Added `sku` identifiers to both product offers (self-serve and analyst review) for better structured data clarity
- Included detailed comments explaining Google's requirements and policy constraints

**Configuration Updates (_config.yml)**
- Added `product-image` configuration with documentation for Google's image requirements
- Added commented-out `product-rating` template with instructions for enabling once real reviews exist
- Fixed navbar link to use trailing slash for consistency (`resume-help/`)

**URL Consistency Fixes**
- Updated all internal links to `/resume-help/` with trailing slash across:
  - index.html (2 occurrences)
  - 404.html
  - about.html
- Updated navbar configuration to use trailing slash

**Documentation**
- Added .gitignore entry explaining why Gemfile.lock is intentionally untracked (GitHub Pages dependency tracking)

## Implementation Details
The schema markup changes follow Google's structured data policies:
- The `image` field is now required and will prevent the Product markup from being dropped from rich results if missing
- The `aggregateRating` field only renders when both `value` and `count` are present in configuration, preventing policy violations from fabricated ratings
- All URLs now consistently use trailing slashes, improving Jekyll's directory-based routing

https://claude.ai/code/session_019JKbYsBqMSy11yUPHJigBz